### PR TITLE
allow customizing the admin paths

### DIFF
--- a/modules/waf-regional/README.md
+++ b/modules/waf-regional/README.md
@@ -65,6 +65,7 @@ References
 | blacklisted\_ips | List of IPs to blacklist, eg ['1.1.1.1/32', '2.2.2.2/32', '3.3.3.3/32'] | `list(string)` | `[]` | no |
 | log\_destination\_arn | Amazon Resource Name (ARN) of Kinesis Firehose Delivery Stream | `string` | `""` | no |
 | rule\_admin\_access\_action\_type | Rule action type. Either BLOCK, ALLOW, or COUNT (useful for testing) | `string` | `"COUNT"` | no |
+| rule\_admin\_path\_constraints | Customize which paths are considered to be admin paths. | `list(object({target_string=string, positional_constraint=string}))` | `[{target_string = "/admin", positional_constraint = "STARTS_WITH"}]` | no |
 | rule\_auth\_tokens\_action | Rule action type. Either BLOCK, ALLOW, or COUNT (useful for testing) | `string` | `"COUNT"` | no |
 | rule\_blacklisted\_ips\_action\_type | Rule action type. Either BLOCK, ALLOW, or COUNT (useful for testing) | `string` | `"COUNT"` | no |
 | rule\_csrf\_action\_type | Rule action type. Either BLOCK, ALLOW, or COUNT (useful for testing) | `string` | `"COUNT"` | no |

--- a/modules/waf-regional/variables.tf
+++ b/modules/waf-regional/variables.tf
@@ -51,6 +51,12 @@ variable rule_admin_access_action_type {
   description = "Rule action type. Either BLOCK, ALLOW, or COUNT (useful for testing)"
 }
 
+variable rule_admin_path_constraints {
+  type        = list(object({target_string=string, positional_constraint=string}))
+  default     = [{target_string = "/admin", positional_constraint = "STARTS_WITH"}]
+  description = "Customize which paths are considered to be admin paths."
+}
+
 variable rule_php_insecurities_action_type {
   type        = string
   default     = "COUNT"

--- a/modules/waf-regional/wafregional_ruleset5_admin_access.tf
+++ b/modules/waf-regional/wafregional_ruleset5_admin_access.tf
@@ -36,14 +36,17 @@ resource aws_wafregional_ipset admin_remote_ipset {
 resource "aws_wafregional_byte_match_set" "match_admin_url" {
   name = "${var.waf_prefix}-generic-match-admin-url"
 
-  byte_match_tuples {
-    text_transformation   = "URL_DECODE"
-    target_string         = "/admin"
-    positional_constraint = "STARTS_WITH"
+  dynamic byte_match_tuples {
+    for_each = var.rule_admin_path_constraints
 
-    field_to_match {
-      type = "URI"
+    content {
+      text_transformation   = "URL_DECODE"
+      target_string         = byte_match_tuples.value.target_string
+      positional_constraint = byte_match_tuples.value.positional_constraint
+
+      field_to_match {
+        type = "URI"
+      }
     }
   }
 }
-


### PR DESCRIPTION
## what
* Support custom admin path matches

## why
* Many websites do not have all of their admin pages under a single hard-coded `/admin` path
* It is not worth forking a module, simply to customize paths.
* The changes are small and easy to maintain

## references


