### PR TITLE
Support logging configuration

### DIFF
--- a/modules/waf-regional/README.md
+++ b/modules/waf-regional/README.md
@@ -65,6 +65,7 @@ References
 | blacklisted\_ips | List of IPs to blacklist, eg ['1.1.1.1/32', '2.2.2.2/32', '3.3.3.3/32'] | `list(string)` | `[]` | no |
 | log\_destination\_arn | Amazon Resource Name (ARN) of Kinesis Firehose Delivery Stream | `string` | `""` | no |
 | rule\_admin\_access\_action\_type | Rule action type. Either BLOCK, ALLOW, or COUNT (useful for testing) | `string` | `"COUNT"` | no |
+| rule\_admin\_path\_constraints | Customize which paths are considered to be admin paths. | `list(object({target_string=string, positional_constraint=string}))` | `[{target_string = "/admin", positional_constraint = "STARTS_WITH"}]` | no |
 | rule\_auth\_tokens\_action | Rule action type. Either BLOCK, ALLOW, or COUNT (useful for testing) | `string` | `"COUNT"` | no |
 | rule\_blacklisted\_ips\_action\_type | Rule action type. Either BLOCK, ALLOW, or COUNT (useful for testing) | `string` | `"COUNT"` | no |
 | rule\_csrf\_action\_type | Rule action type. Either BLOCK, ALLOW, or COUNT (useful for testing) | `string` | `"COUNT"` | no |

--- a/modules/waf-regional/main.tf
+++ b/modules/waf-regional/main.tf
@@ -134,13 +134,26 @@ resource "aws_wafregional_web_acl" "wafregional_acl" {
     type     = "REGULAR"
   }
 
-  #
-  # If you want to send WAF logs to Kinesis Firehose "
-  # UNCOMMENT block below to allow it
-  #
-  #logging_configuration {
-  #  log_destination = var.log_destination_arn
-  #}
+  # Logging configuration when there are no redacted fields.
+  dynamic logging_configuration {
+    for_each = var.enable_logging && length(var.log_redacted_fields == 0) ? [true] : []
+
+    content {
+      log_destination = var.log_destination_arn
+    }
+  }
+
+  # Logging configuration when there are redacted fields.
+  dynamic logging_configuration {
+    for_each = var.enable_logging && length(var.log_redacted_fields > 0) ? [true] : []
+
+    content {
+      log_destination = var.log_destination_arn
+      redacted_fields {
+        field_to_match = var.log_redacted_fields
+      }
+    }
+  }
 
   tags = var.tags
 }

--- a/modules/waf-regional/main.tf
+++ b/modules/waf-regional/main.tf
@@ -136,7 +136,7 @@ resource "aws_wafregional_web_acl" "wafregional_acl" {
 
   # Logging configuration when there are no redacted fields.
   dynamic logging_configuration {
-    for_each = var.enable_logging && length(var.log_redacted_fields == 0) ? [true] : []
+    for_each = var.enable_logging && length(var.log_redacted_fields) == 0 ? [true] : []
 
     content {
       log_destination = var.log_destination_arn
@@ -145,7 +145,7 @@ resource "aws_wafregional_web_acl" "wafregional_acl" {
 
   # Logging configuration when there are redacted fields.
   dynamic logging_configuration {
-    for_each = var.enable_logging && length(var.log_redacted_fields > 0) ? [true] : []
+    for_each = var.enable_logging && length(var.log_redacted_fields) > 0 ? [true] : []
 
     content {
       log_destination = var.log_destination_arn

--- a/modules/waf-regional/main.tf
+++ b/modules/waf-regional/main.tf
@@ -134,23 +134,22 @@ resource "aws_wafregional_web_acl" "wafregional_acl" {
     type     = "REGULAR"
   }
 
-  # Logging configuration when there are no redacted fields.
+  # Logging configuration
   dynamic logging_configuration {
-    for_each = var.enable_logging && length(var.log_redacted_fields) == 0 ? [true] : []
+    for_each = var.enable_logging ? [true] : []
 
     content {
       log_destination = var.log_destination_arn
-    }
-  }
 
-  # Logging configuration when there are redacted fields.
-  dynamic logging_configuration {
-    for_each = var.enable_logging && length(var.log_redacted_fields) > 0 ? [true] : []
+      dynamic redacted_fields {
+        for_each = var.log_redacted_fields
 
-    content {
-      log_destination = var.log_destination_arn
-      redacted_fields {
-        field_to_match = var.log_redacted_fields
+        content {
+          field_to_match {
+            type = redacted_fields.value.type
+            data = redacted_fields.value.data
+          }
+        }
       }
     }
   }

--- a/modules/waf-regional/variables.tf
+++ b/modules/waf-regional/variables.tf
@@ -51,6 +51,12 @@ variable rule_admin_access_action_type {
   description = "Rule action type. Either BLOCK, ALLOW, or COUNT (useful for testing)"
 }
 
+variable rule_admin_path_constraints {
+  type        = list(object({target_string=string, positional_constraint=string}))
+  default     = [{target_string = "/admin", positional_constraint = "STARTS_WITH"}]
+  description = "Customize which paths are considered to be admin paths."
+}
+
 variable rule_php_insecurities_action_type {
   type        = string
   default     = "COUNT"

--- a/modules/waf-regional/variables.tf
+++ b/modules/waf-regional/variables.tf
@@ -93,9 +93,21 @@ variable rule_blacklisted_ips_action_type {
   description = "Rule action type. Either BLOCK, ALLOW, or COUNT (useful for testing)"
 }
 
+variable enable_logging {
+  type        = bool
+  default     = false
+  description = "Enables logging for the WAF"
+}
+
 variable log_destination_arn {
   type        = string
   default     = ""
+  description = "Amazon Resource Name (ARN) of Kinesis Firehose Delivery Stream"
+}
+
+variable log_redacted_fields {
+  type        = list(object({type=string, data=string}))
+  default     = []
   description = "Amazon Resource Name (ARN) of Kinesis Firehose Delivery Stream"
 }
 

--- a/modules/waf-regional/wafregional_ruleset5_admin_access.tf
+++ b/modules/waf-regional/wafregional_ruleset5_admin_access.tf
@@ -36,14 +36,17 @@ resource aws_wafregional_ipset admin_remote_ipset {
 resource "aws_wafregional_byte_match_set" "match_admin_url" {
   name = "${var.waf_prefix}-generic-match-admin-url"
 
-  byte_match_tuples {
-    text_transformation   = "URL_DECODE"
-    target_string         = "/admin"
-    positional_constraint = "STARTS_WITH"
+  dynamic byte_match_tuples {
+    for_each = var.rule_admin_path_constraints
 
-    field_to_match {
-      type = "URI"
+    content {
+      text_transformation   = "URL_DECODE"
+      target_string         = byte_match_tuples.value.target_string
+      positional_constraint = byte_match_tuples.value.positional_constraint
+
+      field_to_match {
+        type = "URI"
+      }
     }
   }
 }
-


### PR DESCRIPTION
## what
* Add opt-in support logging configuration
* Support customizable field redactions

## why
* Many high-security installations will require logging for the WAF
* Sometimes, it is very important to be able to redact certain fields from the logs

## references


