### PR TITLE
CSRF protection to should extend to all state changing operations

### DIFF
--- a/modules/waf-regional/variables.tf
+++ b/modules/waf-regional/variables.tf
@@ -75,6 +75,18 @@ variable rule_csrf_action_type {
   description = "Rule action type. Either BLOCK, ALLOW, or COUNT (useful for testing)"
 }
 
+variable rule_csrf_exclude_methods {
+  type        = list(string)
+  default     = ["get", "head", "options"]
+  description = "HTTP methods to exclude from CSRF checks (if using include, leave this empty)"
+}
+
+variable rule_csrf_include_methods {
+  type        = list(string)
+  default     = []
+  description = "HTTP methods to include in CSRF checks (if using exclude, leave this empty)"
+}
+
 variable rule_csrf_header {
   type        = string
   description = "The name of your CSRF token header."

--- a/modules/waf-regional/wafregional_ruleset8_csrf.tf
+++ b/modules/waf-regional/wafregional_ruleset8_csrf.tf
@@ -10,7 +10,7 @@ resource "aws_wafregional_rule" "enforce_csrf" {
   dynamic predicate {
     for_each = var.rule_csrf_exclude_methods
     content {
-      data_id = aws_wafregional_byte_match_set.exclude_csrf_method[predicate.key].id
+      data_id = aws_wafregional_byte_match_set.exclude_csrf_method[predicate.value].id
       negated = true
       type    = "ByteMatch"
     }
@@ -19,7 +19,7 @@ resource "aws_wafregional_rule" "enforce_csrf" {
   dynamic predicate {
     for_each = var.rule_csrf_include_methods
     content {
-      data_id = aws_wafregional_byte_match_set.include_csrf_method[predicate.key].id
+      data_id = aws_wafregional_byte_match_set.include_csrf_method[predicate.value].id
       negated = false
       type = "ByteMatch"
     }

--- a/modules/waf-regional/wafregional_ruleset8_csrf.tf
+++ b/modules/waf-regional/wafregional_ruleset8_csrf.tf
@@ -33,7 +33,7 @@ resource "aws_wafregional_rule" "enforce_csrf" {
 }
 
 resource "aws_wafregional_byte_match_set" "exclude_csrf_method" {
-  for_each = var.rule_csrf_exclude_methods
+  for_each = toset(var.rule_csrf_exclude_methods)
   name = "${var.waf_prefix}-generic-exclude-csrf-method-${each.value}"
 
   byte_match_tuples {
@@ -48,7 +48,7 @@ resource "aws_wafregional_byte_match_set" "exclude_csrf_method" {
 }
 
 resource "aws_wafregional_byte_match_set" "include_csrf_method" {
-  for_each = var.rule_csrf_include_methods
+  for_each = toset(var.rule_csrf_include_methods)
   name = "${var.waf_prefix}-generic-include-csrf-method-${each.value}"
 
   byte_match_tuples {


### PR DESCRIPTION
## what
* Extends CSRF policy to more than just POST, defaulting to all methods except GET, HEAD, OPTIONS

## why
* CSRF protection to should extend to all state changing operations

## references
* fixes #22 
* https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html

