### PR TITLE
Issue | Customize CSRF headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ module "waf_regional_test" {
     rule_php_insecurities_action_type   = "COUNT"
     rule_csrf_action_type               = "COUNT"
     rule_blacklisted_ips_action_type    = "COUNT"
+
+    # Set custom header for CSRF Token
+    custom_csrf_token = [
+      {
+        field = "X-Twilio-Signature"
+        size = 28
+        operator = "GT"
+      }
+    ]
 }
 ```
 

--- a/modules/waf-global/README.md
+++ b/modules/waf-global/README.md
@@ -124,6 +124,7 @@ No modules.
 | <a name="input_rule_xss_action"></a> [rule\_xss\_action](#input\_rule\_xss\_action) | Rule action type. Either BLOCK, ALLOW, or COUNT (useful for testing) | `string` | `"COUNT"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
 | <a name="input_waf_prefix"></a> [waf\_prefix](#input\_waf\_prefix) | Prefix to use when naming resources | `string` | n/a | yes |
+| <a name="input_custom_csrf_token"></a> [custom\_csrf\_token](#input\_custom\_csrf\_token) | Custom CSRF Tokens | `list(map(string))` | '[]' | no |
 
 ## Outputs
 

--- a/modules/waf-global/README.md
+++ b/modules/waf-global/README.md
@@ -99,6 +99,7 @@ No modules.
 | [aws_waf_rule.mitigate_xss](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/waf_rule) | resource |
 | [aws_waf_rule.restrict_sizes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/waf_rule) | resource |
 | [aws_waf_size_constraint_set.csrf_token_set](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/waf_size_constraint_set) | resource |
+| [aws_waf_size_constraint_set.custom_csrf_token_set](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/waf_size_constraint_set) | resource |
 | [aws_waf_size_constraint_set.size_restrictions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/waf_size_constraint_set) | resource |
 | [aws_waf_sql_injection_match_set.sql_injection_match_set](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/waf_sql_injection_match_set) | resource |
 | [aws_waf_web_acl.waf_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/waf_web_acl) | resource |
@@ -110,6 +111,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_admin_remote_ipset"></a> [admin\_remote\_ipset](#input\_admin\_remote\_ipset) | List of IPs allowed to access admin pages, ['1.1.1.1/32', '2.2.2.2/32', '3.3.3.3/32'] | `list(string)` | `[]` | no |
 | <a name="input_blacklisted_ips"></a> [blacklisted\_ips](#input\_blacklisted\_ips) | List of IPs to blacklist, eg ['1.1.1.1/32', '2.2.2.2/32', '3.3.3.3/32'] | `list(string)` | `[]` | no |
+| <a name="input_custom_csrf_token"></a> [custom\_csrf\_token](#input\_custom\_csrf\_token) | Custom CSRF token set | `list` | `[]` | no |
 | <a name="input_rule_admin_access_action_type"></a> [rule\_admin\_access\_action\_type](#input\_rule\_admin\_access\_action\_type) | Rule action type. Either BLOCK, ALLOW, or COUNT (useful for testing) | `string` | `"COUNT"` | no |
 | <a name="input_rule_auth_tokens_action"></a> [rule\_auth\_tokens\_action](#input\_rule\_auth\_tokens\_action) | Rule action type. Either BLOCK, ALLOW, or COUNT (useful for testing) | `string` | `"COUNT"` | no |
 | <a name="input_rule_blacklisted_ips_action_type"></a> [rule\_blacklisted\_ips\_action\_type](#input\_rule\_blacklisted\_ips\_action\_type) | Rule action type. Either BLOCK, ALLOW, or COUNT (useful for testing) | `string` | `"COUNT"` | no |
@@ -124,7 +126,6 @@ No modules.
 | <a name="input_rule_xss_action"></a> [rule\_xss\_action](#input\_rule\_xss\_action) | Rule action type. Either BLOCK, ALLOW, or COUNT (useful for testing) | `string` | `"COUNT"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
 | <a name="input_waf_prefix"></a> [waf\_prefix](#input\_waf\_prefix) | Prefix to use when naming resources | `string` | n/a | yes |
-| <a name="input_custom_csrf_token"></a> [custom\_csrf\_token](#input\_custom\_csrf\_token) | Custom CSRF Tokens | `list(map(string))` | '[]' | no |
 
 ## Outputs
 

--- a/modules/waf-global/variables.tf
+++ b/modules/waf-global/variables.tf
@@ -95,5 +95,5 @@ variable "tags" {
 
 variable "custom_csrf_token" {
   description = "Custom CSRF token set"
-  default = []
+  default     = []
 }

--- a/modules/waf-global/variables.tf
+++ b/modules/waf-global/variables.tf
@@ -92,3 +92,8 @@ variable "tags" {
   description = "A mapping of tags to assign to all resources"
   default     = {}
 }
+
+variable "custom_csrf_token" {
+  description = "Custom CSRF token set"
+  default = []
+}

--- a/modules/waf-global/waf_ruleset8_csrf.tf
+++ b/modules/waf-global/waf_ruleset8_csrf.tf
@@ -49,3 +49,19 @@ resource "aws_waf_size_constraint_set" "csrf_token_set" {
   }
 }
 
+resource "aws_waf_size_constraint_set" "custom_csrf_token_set" {
+  count = length(var.custom_csrf_token)
+
+  name = "${var.waf_prefix}-${lower(var.custom_csrf_token[count.index].field)}-custom-csrf-token"
+
+  size_constraints {
+    text_transformation = "NONE"
+    comparison_operator = var.custom_csrf_token[count.index].operator
+    size                = var.custom_csrf_token[count.index].size
+
+    field_to_match {
+      type = "HEADER"
+      data = var.custom_csrf_token[count.index].field
+    }
+  }
+}

--- a/modules/waf-regional/README.md
+++ b/modules/waf-regional/README.md
@@ -134,6 +134,7 @@ No modules.
 | <a name="input_rule_xss_action"></a> [rule\_xss\_action](#input\_rule\_xss\_action) | Rule action type. Either BLOCK, ALLOW, or COUNT (useful for testing) | `string` | `"COUNT"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
 | <a name="input_waf_prefix"></a> [waf\_prefix](#input\_waf\_prefix) | Prefix to use when naming resources | `string` | n/a | yes |
+| <a name="input_custom_csrf_token"></a> [custom\_csrf\_token](#input\_custom\_csrf\_token) | Custom CSRF Tokens | `list(map(string))` | '[]' | no |
 
 ## Outputs
 

--- a/modules/waf-regional/README.md
+++ b/modules/waf-regional/README.md
@@ -102,6 +102,7 @@ No modules.
 | [aws_wafregional_rule.mitigate_xss](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafregional_rule) | resource |
 | [aws_wafregional_rule.restrict_sizes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafregional_rule) | resource |
 | [aws_wafregional_size_constraint_set.csrf_token_set](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafregional_size_constraint_set) | resource |
+| [aws_wafregional_size_constraint_set.custom_csrf_token_set](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafregional_size_constraint_set) | resource |
 | [aws_wafregional_size_constraint_set.size_restrictions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafregional_size_constraint_set) | resource |
 | [aws_wafregional_sql_injection_match_set.sql_injection_match_set](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafregional_sql_injection_match_set) | resource |
 | [aws_wafregional_web_acl.wafregional_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafregional_web_acl) | resource |
@@ -115,6 +116,7 @@ No modules.
 | <a name="input_admin_remote_ipset"></a> [admin\_remote\_ipset](#input\_admin\_remote\_ipset) | List of IPs allowed to access admin pages, ['1.1.1.1/32', '2.2.2.2/32', '3.3.3.3/32'] | `list(string)` | `[]` | no |
 | <a name="input_alb_arn"></a> [alb\_arn](#input\_alb\_arn) | List of ALB ARNs | `list(string)` | `[]` | no |
 | <a name="input_blacklisted_ips"></a> [blacklisted\_ips](#input\_blacklisted\_ips) | List of IPs to blacklist, eg ['1.1.1.1/32', '2.2.2.2/32', '3.3.3.3/32'] | `list(string)` | `[]` | no |
+| <a name="input_custom_csrf_token"></a> [custom\_csrf\_token](#input\_custom\_csrf\_token) | Custom CSRF token set | `list` | `[]` | no |
 | <a name="input_enable_logging"></a> [enable\_logging](#input\_enable\_logging) | Enables logging for the WAF | `bool` | `false` | no |
 | <a name="input_log_destination_arn"></a> [log\_destination\_arn](#input\_log\_destination\_arn) | Amazon Resource Name (ARN) of Kinesis Firehose Delivery Stream | `string` | `""` | no |
 | <a name="input_log_redacted_fields"></a> [log\_redacted\_fields](#input\_log\_redacted\_fields) | Amazon Resource Name (ARN) of Kinesis Firehose Delivery Stream | `list(object({ type = string, data = string }))` | `[]` | no |
@@ -134,7 +136,6 @@ No modules.
 | <a name="input_rule_xss_action"></a> [rule\_xss\_action](#input\_rule\_xss\_action) | Rule action type. Either BLOCK, ALLOW, or COUNT (useful for testing) | `string` | `"COUNT"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
 | <a name="input_waf_prefix"></a> [waf\_prefix](#input\_waf\_prefix) | Prefix to use when naming resources | `string` | n/a | yes |
-| <a name="input_custom_csrf_token"></a> [custom\_csrf\_token](#input\_custom\_csrf\_token) | Custom CSRF Tokens | `list(map(string))` | '[]' | no |
 
 ## Outputs
 

--- a/modules/waf-regional/variables.tf
+++ b/modules/waf-regional/variables.tf
@@ -131,5 +131,5 @@ variable "tags" {
 
 variable "custom_csrf_token" {
   description = "Custom CSRF token set"
-  default = []
+  default     = []
 }

--- a/modules/waf-regional/variables.tf
+++ b/modules/waf-regional/variables.tf
@@ -128,3 +128,8 @@ variable "tags" {
   description = "A mapping of tags to assign to all resources"
   default     = {}
 }
+
+variable "custom_csrf_token" {
+  description = "Custom CSRF token set"
+  default = []
+}

--- a/modules/waf-regional/wafregional_ruleset8_csrf.tf
+++ b/modules/waf-regional/wafregional_ruleset8_csrf.tf
@@ -118,3 +118,20 @@ resource "aws_wafregional_byte_match_set" "csrf_fetch_same_origin" {
     }
   }
 }
+
+resource "aws_wafregional_size_constraint_set" "custom_csrf_token_set" {
+  count = length(var.custom_csrf_token)
+
+  name = "${var.waf_prefix}-${lower(var.custom_csrf_token[count.index].field)}-custom-csrf-token"
+
+  size_constraints {
+    text_transformation = "NONE"
+    comparison_operator = var.custom_csrf_token[count.index].operator
+    size                = var.custom_csrf_token[count.index].size
+
+    field_to_match {
+      type = "HEADER"
+      data = var.custom_csrf_token[count.index].field
+    }
+  }
+}


### PR DESCRIPTION
## what
* Add the possibility to set custom headers for CSRF.
* Update corresponding documentation

## why
* Compatibility with APIs with no custom headers

## references
* `closes #30`

