### PR TITLE
Issue | Present association possibility for other resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ module "waf_regional_test" {
     # List of IPs that are allowed to access admin pages
     admin_remote_ipset = []
 
-    # Pass the list of ALB ARNs that the WAF ACL will be connected to
-    alb_arn = [
+    # Pass the list of resources ARNs that the WAF ACL will be connected to. (For example, an Application Load Balancer or API Gateway Stage.)
+    resource_arn = [
         "arn:aws:elasticloadbalancing:us-east-2:1234567890:loadbalancer/app/some-LB-ABCD1233/12345111",
         "arn:aws:elasticloadbalancing:us-east-2:1234567890:loadbalancer/app/some-LB-ABCD1244/12345222"
     ]

--- a/examples/waf-regional-alb/README.md
+++ b/examples/waf-regional-alb/README.md
@@ -55,8 +55,8 @@ module "waf_regional_test" {
     # List of IPs that are allowed to access admin pages
     admin_remote_ipset = []
 
-    # Pass the list of ALB ARNs that the WAF ACL will be connected to
-    alb_arn = [
+    # Pass the list of resources ARNs that the WAF ACL will be connected to. (For example, an Application Load Balancer or API Gateway Stage.)
+    resource_arn = [
         "arn:aws:elasticloadbalancing:us-east-2:1234567890:loadbalancer/app/some-LB-ABCD1233/12345111",
         "arn:aws:elasticloadbalancing:us-east-2:1234567890:loadbalancer/app/some-LB-ABCD1244/12345222"
     ]

--- a/examples/waf-regional-alb/main.tf
+++ b/examples/waf-regional-alb/main.tf
@@ -17,8 +17,8 @@ module "waf_regional_test" {
   # List of IPs that are allowed to access admin pages
   admin_remote_ipset = []
 
-  # Pass the list of ALB ARNs that the WAF ACL will be connected to
-  alb_arn = [
+  # Pass the list of resources ARNs that the WAF ACL will be connected to. (For example, an Application Load Balancer or API Gateway Stage.)
+  resource_arn = [
     "arn:aws:elasticloadbalancing:us-east-2:1234567890:loadbalancer/app/some-LB-ABCD1233/12345111",
     "arn:aws:elasticloadbalancing:us-east-2:1234567890:loadbalancer/app/some-LB-ABCD1244/12345222"
   ]

--- a/modules/waf-regional/README.md
+++ b/modules/waf-regional/README.md
@@ -113,11 +113,11 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_admin_remote_ipset"></a> [admin\_remote\_ipset](#input\_admin\_remote\_ipset) | List of IPs allowed to access admin pages, ['1.1.1.1/32', '2.2.2.2/32', '3.3.3.3/32'] | `list(string)` | `[]` | no |
-| <a name="input_resource_arn"></a> [alb\_arn](#input\_alb\_arn) | List of ARN of the resources to associate with. For example, an Application Load Balancer or API Gateway Stage. | `list(string)` | `[]` | no |
 | <a name="input_blacklisted_ips"></a> [blacklisted\_ips](#input\_blacklisted\_ips) | List of IPs to blacklist, eg ['1.1.1.1/32', '2.2.2.2/32', '3.3.3.3/32'] | `list(string)` | `[]` | no |
 | <a name="input_enable_logging"></a> [enable\_logging](#input\_enable\_logging) | Enables logging for the WAF | `bool` | `false` | no |
 | <a name="input_log_destination_arn"></a> [log\_destination\_arn](#input\_log\_destination\_arn) | Amazon Resource Name (ARN) of Kinesis Firehose Delivery Stream | `string` | `""` | no |
 | <a name="input_log_redacted_fields"></a> [log\_redacted\_fields](#input\_log\_redacted\_fields) | Amazon Resource Name (ARN) of Kinesis Firehose Delivery Stream | `list(object({ type = string, data = string }))` | `[]` | no |
+| <a name="input_resource_arn"></a> [resource\_arn](#input\_resource\_arn) | List of ARNs of the resource to associate with | `list(string)` | `[]` | no |
 | <a name="input_rule_admin_access_action_type"></a> [rule\_admin\_access\_action\_type](#input\_rule\_admin\_access\_action\_type) | Rule action type. Either BLOCK, ALLOW, or COUNT (useful for testing) | `string` | `"COUNT"` | no |
 | <a name="input_rule_admin_path_constraints"></a> [rule\_admin\_path\_constraints](#input\_rule\_admin\_path\_constraints) | Customize which paths are considered to be admin paths. | `list(object({ target_string = string, positional_constraint = string }))` | <pre>[<br>  {<br>    "positional_constraint": "STARTS_WITH",<br>    "target_string": "/admin"<br>  }<br>]</pre> | no |
 | <a name="input_rule_auth_tokens_action"></a> [rule\_auth\_tokens\_action](#input\_rule\_auth\_tokens\_action) | Rule action type. Either BLOCK, ALLOW, or COUNT (useful for testing) | `string` | `"COUNT"` | no |

--- a/modules/waf-regional/README.md
+++ b/modules/waf-regional/README.md
@@ -113,7 +113,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_admin_remote_ipset"></a> [admin\_remote\_ipset](#input\_admin\_remote\_ipset) | List of IPs allowed to access admin pages, ['1.1.1.1/32', '2.2.2.2/32', '3.3.3.3/32'] | `list(string)` | `[]` | no |
-| <a name="input_alb_arn"></a> [alb\_arn](#input\_alb\_arn) | List of ALB ARNs | `list(string)` | `[]` | no |
+| <a name="input_resource_arn"></a> [alb\_arn](#input\_alb\_arn) | List of ARN of the resources to associate with. For example, an Application Load Balancer or API Gateway Stage. | `list(string)` | `[]` | no |
 | <a name="input_blacklisted_ips"></a> [blacklisted\_ips](#input\_blacklisted\_ips) | List of IPs to blacklist, eg ['1.1.1.1/32', '2.2.2.2/32', '3.3.3.3/32'] | `list(string)` | `[]` | no |
 | <a name="input_enable_logging"></a> [enable\_logging](#input\_enable\_logging) | Enables logging for the WAF | `bool` | `false` | no |
 | <a name="input_log_destination_arn"></a> [log\_destination\_arn](#input\_log\_destination\_arn) | Amazon Resource Name (ARN) of Kinesis Firehose Delivery Stream | `string` | `""` | no |
@@ -160,8 +160,8 @@ module "waf_regional_test" {
     # List of IPs that are allowed to access admin pages
     admin_remote_ipset = []
 
-    # Pass the list of ALB ARNs that the WAF ACL will be connected to
-    alb_arn = [
+    # Pass the list of resources ARNs that the WAF ACL will be connected to. (For example, an Application Load Balancer or API Gateway Stage.)
+    resource_arn = [
         "arn:aws:elasticloadbalancing:us-east-2:1234567890:loadbalancer/app/some-LB-ABCD1233/12345111",
         "arn:aws:elasticloadbalancing:us-east-2:1234567890:loadbalancer/app/some-LB-ABCD1244/12345222"
     ]

--- a/modules/waf-regional/main.tf
+++ b/modules/waf-regional/main.tf
@@ -162,8 +162,8 @@ resource "aws_wafregional_web_acl" "wafregional_acl" {
 #
 resource "aws_wafregional_web_acl_association" "acl_alb_association" {
   depends_on   = [aws_wafregional_web_acl.wafregional_acl]
-  count        = length(var.alb_arn)
-  resource_arn = var.alb_arn[count.index]
+  count        = length(var.resource_arn)
+  resource_arn = var.resource_arn[count.index]
   web_acl_id   = aws_wafregional_web_acl.wafregional_acl.id
 }
 

--- a/modules/waf-regional/tests/fixture/main.tf
+++ b/modules/waf-regional/tests/fixture/main.tf
@@ -37,8 +37,8 @@ module "waf_regional_test" {
   # List of IPs that are allowed to access admin pages
   admin_remote_ipset = var.admin_remote_ipset
 
-  # Pass the list of ALB ARNs that the WAF ACL will be connected to
-  alb_arn = [aws_lb.waf_assoc_1.arn, aws_lb.waf_assoc_2.arn, ]
+  # Pass the list of resources ARNs that the WAF ACL will be connected to. (For example, an Application Load Balancer or API Gateway Stage.)
+  resource_arn = [aws_lb.waf_assoc_1.arn, aws_lb.waf_assoc_2.arn, ]
 
   # By default seted to COUNT for testing in order to avoid service affection; when ready, set it to BLOCK
   rule_size_restriction_action_type = "COUNT"

--- a/modules/waf-regional/variables.tf
+++ b/modules/waf-regional/variables.tf
@@ -15,10 +15,10 @@ variable "admin_remote_ipset" {
   description = "List of IPs allowed to access admin pages, ['1.1.1.1/32', '2.2.2.2/32', '3.3.3.3/32']"
 }
 
-variable "alb_arn" {
+variable "resource_arn" {
   type        = list(string)
   default     = []
-  description = "List of ALB ARNs"
+  description = "List of ARNs of the resource to associate with"
 }
 
 variable "rule_sqli_action" {


### PR DESCRIPTION
## what
* rename `alb_arn` to `resource_arn`
* update docs

## why
* present the association possibility for other resources. For example, an Application Load Balancer or API Gateway Stage.

## references
* `closes #32`

